### PR TITLE
feat: backend API 연동 (secrets.toml 사용)

### DIFF
--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,0 +1,8 @@
+[api]
+fastapi_base_url = "http://backend:8000"
+
+[airflow]
+url = "http://airflow:8080"
+username = "admin"
+password = "admin"
+dag_id = "mri_pipeline"


### PR DESCRIPTION
# Secrets.toml 업로드
- .streamlit/secrets.toml 추가 (api.fastapi_base_url, airflow.url/username/password/dag_id)
- app_pages/run_pipeline.py에서 st.secrets 사용하도록 수정
- 기본 URL 도커 네트워크 기준으로 정리 (http://backend:8000, http://airflow:8080)
- 로컬/도커에서 API 호출 및 DAG 트리거 동작 확인

## 확인
`docker-compose up -d --build`
`# Streamlit 접속 후 아리스/파이프라인 실행 → 상태/로그 수신 확인`

